### PR TITLE
Pass `block` parameter through in `MultiPort._receive()`

### DIFF
--- a/mido/ports.py
+++ b/mido/ports.py
@@ -369,7 +369,7 @@ class MultiPort(BaseIOPort):
     def _receive(self, block=True):
         self._messages.extend(multi_receive(self.ports,
                                             yield_ports=self.yield_ports,
-                                            block=False))
+                                            block=block))
 
 
 def multi_receive(ports, yield_ports=False, block=True):


### PR DESCRIPTION
I saw this while going over the source!

I haven't actually encountered a problem due to what I perceive is an issue on this line - it might be the correct behavior for some reason I haven't figured out.

If it's right, let me know and I'll change the commit to be a comment explaining it.

Thanks for an excellent library!
